### PR TITLE
Test case fixes

### DIFF
--- a/test/HierarchyTest.hs
+++ b/test/HierarchyTest.hs
@@ -3,6 +3,7 @@ module HierarchyTest
     ) where
 
 import Control.Monad (liftM2)
+import Data.List (nub)
 import Data.Either (isRight)
 import H3.Indexing 
   ( latLngToCell
@@ -70,7 +71,8 @@ testCompactCellsSucceeds :: Test
 testCompactCellsSucceeds = testProperty "Testing compactCells returns successfully" $ \genLatLngs (Resolution res) ->
     let latLngs = map fromGenLatLng genLatLngs
         cellSetE = mapM (flip latLngToCell res) latLngs
-        resultE = cellSetE >>= compactCells 
+        cellSetDedupE = nub <$> cellSetE -- deduplicate the list of cells, otherwise we will get E_DUPLICATE_INPUT
+        resultE = cellSetDedupE >>= compactCells 
     in isRight resultE
 
 testUncompactCellsSucceeds :: Test

--- a/test/VertexesTest.hs
+++ b/test/VertexesTest.hs
@@ -47,7 +47,8 @@ testCellToVertex = testProperty "Test cellToVertex produces valid vertex indices
 testCellToVertexes :: Test
 testCellToVertexes = testProperty "Test cellToVertexes produces valid vertex indices" $ \(GenLatLng latLng) (Resolution res) ->
     let h3indexE = latLngToCell latLng res
-        vertexesE = h3indexE >>= cellToVertexes
+        allVertexesE = h3indexE >>= cellToVertexes
+        vertexesE = (filter (/=0)) <$> allVertexesE -- pentagons will include a 0 for one of the vertexes
         resultE = all isValidVertex <$> vertexesE
     in (resultE == Right True)
 


### PR DESCRIPTION
We encounter occasional errors with some test cases using mock data, namely the tests for 
* `cellToVertexes`, and 
* `compactCells`.

We address these issues here.
