### PR TITLE
Removing unused import

### DIFF
--- a/test/TraversalTest.hs
+++ b/test/TraversalTest.hs
@@ -14,7 +14,6 @@ import H3.Traversal
   ( gridDisk
   , gridDiskUnsafe
   , gridDiskDistances
-  , gridDiskDistancesSafe
   , gridDiskDistancesUnsafe
   , gridRingUnsafe
   , gridPathCells


### PR DESCRIPTION
Forgot to remove import of `gridDiskDistancesSafe`.