### PR TITLE
nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Haskell
 dist-newstyle
+dist-docs
 *.o
 *.hi
 *.chi

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1735563628,
+        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
+        "lastModified": 1772822230,
+        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
+        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-25.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,168 @@
+# Ideally I'd like to set 
+#   build-tool-depends: c2hs:c2hs
+# in the h3-hs.cabal file, but unfortunately this appears 
+# to cause an issue in the development shells below.
+# If we enable `build-tool-depends`, we can use 
+# `nix develop`, but then from within that development shell, 
+# we get cabal build errors on account of the handling of c2hs.
+# This appears to be documented in the references below, though please 
+# not that not all of the references might refer to the root issue.
+# As a work around, we comment out or disable 
+# `build-tool-depends` and instead override 
+# the cabal derivation attribute `nativeBuildInputs` to include `c2hs`.
+# This appears to allow us both to enter the shell (which itself performs
+# a build of `h3-hs`) and use cabal to rebuild and test the package.
+# References:
+# * https://github.com/input-output-hk/haskell.nix/issues/760
+# * https://github.com/input-output-hk/haskell.nix/issues/231
+# * https://github.com/input-output-hk/haskell.nix/issues/839
+# * https://github.com/input-output-hk/haskell.nix/issues/1367#issuecomment-1207454622
+# * https://github.com/haskell/cabal/issues/8434
+{
+  inputs = {
+    nixpkgs = {
+      url = "github:nixos/nixpkgs/nixos-24.05";
+    };
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+    };
+  };
+  outputs = { nixpkgs, flake-utils, ... }: 
+    let
+      h3-hs-source-overlay = final: prev: {
+          haskell = prev.haskell // {
+              packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
+                  finalHaskell: prevHaskell:
+                    let
+                        h3-hs-preliminary = prevHaskell.callCabal2nix "h3-hs" ./. { h3 = final.h3_4; };
+                    in
+                    {
+                      # h3-hs = prevHaskell.callCabal2nix "h3-hs" ./. { h3 = final.h3_4; };
+                      # h3-hs = prevHaskell.h3-hs.override { h3 = final.h3_4; };
+                      # h3-hs = h3-hs-preliminary.overrideAttrs (prevAttrs: {
+                      #     nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ finalHaskell.c2hs ];
+                      # });
+                      h3-hs = h3-hs-preliminary;
+                    }
+              );
+          };
+      };
+      # h3-hs-hackage-overlay = final: prev: {
+      #     haskell = prev.haskell // {
+      #         packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
+      #             finalHaskell: prevHaskell:
+      #               {
+      #                 h3-hs = prevHaskell.callCabal2nix "h3-hs" ./. { h3 = final.h3_4; };
+      #                 # Use the following after upgrading nixpkgs
+      #                 # h3-hs = prevHaskell.h3-hs.override { h3 = final.h3_4; };
+      #               }
+      #         );
+      #     };
+      # };
+    in 
+      flake-utils.lib.eachDefaultSystem (system:
+        let 
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ h3-hs-source-overlay ];
+          };
+          
+          # release-pkgs = import nixpkgs {
+          #   inherit system;
+          #   overlays = [ h3-hs-hackage-overlay ];
+          # };
+   
+          build-package-map = hs: [hs.cabal-install hs.test-framework-quickcheck2 hs.c2hs ]; # hs.c2hs
+          # build-package-map-with-h3 = hs: [hs.cabal-install hs.test-framework-quickcheck2 hs.c2hs hs.h3-hs];
+          haskell-build-packages = [
+              pkgs.which
+              pkgs.h3_4
+              pkgs.pkg-config
+              (pkgs.haskellPackages.ghcWithPackages build-package-map)
+          ];
+          # haskell-build-packages-with-h3 = [
+          #     pkgs.which
+          #     pkgs.h3_4
+          #     pkgs.pkg-config
+          #     (pkgs.haskellPackages.ghcWithPackages build-package-map-with-h3)
+          # ];
+
+          # release-haskell-package-map = hs: [hs.h3-hs hs.cabal-install hs.test-framework-quickcheck2];
+          # release-haskell-packages = [
+          #     pkgs.which
+          #     pkgs.h3_4
+          #     pkgs.pkg-config
+          #     # (pkgs.haskellPackages.ghcWithPackages (hs: [hs.h3-hs hs.cabal-install hs.c2hs hs.test-framework-quickcheck2]))
+          #     # NOTE: Removed c2hs from the following
+          #     (pkgs.haskellPackages.ghcWithPackages release-haskell-package-map) # (hs: [hs.h3-hs hs.cabal-install hs.test-framework-quickcheck2])
+          # ];
+      in rec {
+        # devShell = devShells.default; 
+        # pkgs.mkShell {
+        #   packages = dev-haskell-packages;
+        #   # inputsFrom = dev-haskell-packages;
+        #   nativeBuildInputs = [ pkgs.haskellPackages.c2hs ]; #  dev-haskell-packages;
+        #   # buildInputs = dev-haskell-packages;
+        #   # propagatedBuildInputs = dev-haskell-packages;
+        #   # nativeBuildInputs = dev-haskell-packages;
+        #   # packages = [ 
+        #   #     pkgs.haskellPackages.cabal-install
+        #   #     pkgs.haskellPackages.c2hs
+        #   # ];
+        #   shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev > \\[\\e[0m\\]'";
+        # };
+        devShells = {
+            default = pkgs.mkShell {
+              packages = haskell-build-packages;
+              # inputsFrom = dev-haskell-packages;
+              nativeBuildInputs = [ pkgs.haskellPackages.c2hs ]; #  dev-haskell-packages;
+              # buildInputs = dev-haskell-packages;
+              # propagatedBuildInputs = dev-haskell-packages;
+              # nativeBuildInputs = dev-haskell-packages;
+              # packages = [ 
+              #     pkgs.haskellPackages.cabal-install
+              #     pkgs.haskellPackages.c2hs
+              # ];
+              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev > \\[\\e[0m\\]'";
+            };
+            ex-h3-hs = pkgs.mkShell {
+              packages = [ pkgs.h3_4 (pkgs.haskellPackages.ghcWithPackages (hs: [hs.cabal-install hs.test-framework-quickcheck2])) ];
+              nativeBuildInputs = [ pkgs.haskellPackages.c2hs ];
+              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev (ex h3-hs) > \\[\\e[0m\\]'";
+            };
+            legacy = pkgs.haskellPackages.shellFor {
+                packages = p: [p.h3-hs];
+                withHoogle = true;
+                buildInputs =((with pkgs; [ h3_4 ]) ++ (with pkgs.haskellPackages; [ cabal-install c2hs ]));
+                shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-shellfor > \\[\\e[0m\\]'";
+                # exactDeps = false;
+            };
+            ghc928shell = pkgs.mkShell {
+              packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc928.ghcWithPackages build-package-map) ];
+              # inputsFrom = [ (pkgs.haskell.packages.ghc928.ghcWithPackages (hs: [hs.c2hs])) ];
+              # buildInputs = [ (pkgs.haskell.packages.ghc928.ghcWithPackages (hs: [hs.c2hs])) ];
+              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev (ghc-9.2.8) > \\[\\e[0m\\]'";
+            };
+            ghc982shell = pkgs.mkShell {
+              # buildInputs = [ pkgs.h3_4 (pkgs.haskell.packages.ghc982.ghcWithPackages (hs: [hs.h3-hs hs.cabal-install hs.c2hs hs.test-framework-quickcheck2]))];
+              # inputsFrom = [ (pkgs.haskell.packages.ghc982.ghcWithPackages (hs: [hs.c2hs])) ];
+              # nativeBuildInputs = [ (pkgs.haskell.packages.ghc982.ghcWithPackages (hs: [hs.c2hs])) ];
+              # buildInputs = [ (pkgs.haskell.packages.ghc982.ghcWithPackages (hs: [hs.c2hs])) ];
+              packages = [ pkgs.which pkgs.h3_4 (pkgs.haskell.packages.ghc982.ghcWithPackages build-package-map) ];
+              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev (ghc-9.8.2) > \\[\\e[0m\\]'";
+            };
+            # package-test = pkgs.mkShell {
+            #   packages = haskell-build-packages-with-h3;
+            #   # nativeBuildInputs = [ pkgs.haskellPackages.c2hs ];
+            #   shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs (package test) > \\[\\e[0m\\]'";
+            # };
+        };
+        packages = {
+          h3-hs = pkgs.haskellPackages.h3-hs;
+          default = pkgs.haskellPackages.h3-hs;
+        };
+      }
+    ) // {
+      overlays.default = h3-hs-source-overlay;
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,17 +1,20 @@
-# Ideally I'd like to set 
+# We have decided to set 
 #   build-tool-depends: c2hs:c2hs
-# in the h3-hs.cabal file, but unfortunately this appears 
+# in the h3-hs.cabal file, though unfortunately this appears 
 # to cause an issue in the development shells below.
-# If we enable `build-tool-depends`, we can use 
-# `nix develop`, but then from within that development shell, 
+# We have decided to use this approach as we regard the cabal file as the
+# source of truth for the dependencies of the package, and
+# will work around the issues in the nix development shells.
+# The package successfully builds using the overlay, so the
+# issue is specific to the development shells.
+# The issue is that, by specifying `c2hs` in `build-tool-depends`,
+# we can use `nix develop`, but from within that development shell, 
 # we get cabal build errors on account of the handling of c2hs.
+# Using `cabal update` seems to address this, but as a result `cabal build`
+# will build a local `c2hs` executable, even though a
+# suitable `c2hs` is already available on the path.
 # This appears to be documented in the references below, though please 
-# not that not all of the references might refer to the root issue.
-# As a work around, we comment out or disable 
-# `build-tool-depends` and instead override 
-# the cabal derivation attribute `nativeBuildInputs` to include `c2hs`.
-# This appears to allow us both to enter the shell (which itself performs
-# a build of `h3-hs`) and use cabal to rebuild and test the package.
+# note that not all of the references might refer to the root issue.
 # References:
 # * https://github.com/input-output-hk/haskell.nix/issues/760
 # * https://github.com/input-output-hk/haskell.nix/issues/231
@@ -21,7 +24,7 @@
 {
   inputs = {
     nixpkgs = {
-      url = "github:nixos/nixpkgs/nixos-24.05";
+      url = "github:nixos/nixpkgs/nixos-25.11";
     };
     flake-utils = {
       url = "github:numtide/flake-utils";
@@ -33,32 +36,28 @@
           haskell = prev.haskell // {
               packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
                   finalHaskell: prevHaskell:
-                    let
-                        h3-hs-preliminary = prevHaskell.callCabal2nix "h3-hs" ./. { h3 = final.h3_4; };
-                    in
                     {
-                      # h3-hs = prevHaskell.callCabal2nix "h3-hs" ./. { h3 = final.h3_4; };
-                      # h3-hs = prevHaskell.h3-hs.override { h3 = final.h3_4; };
-                      # h3-hs = h3-hs-preliminary.overrideAttrs (prevAttrs: {
-                      #     nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ finalHaskell.c2hs ];
-                      # });
-                      h3-hs = h3-hs-preliminary;
+                      h3-hs = prevHaskell.callCabal2nix "h3-hs" ./. { h3 = final.h3_4; };
                     }
               );
           };
       };
-      # h3-hs-hackage-overlay = final: prev: {
-      #     haskell = prev.haskell // {
-      #         packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
-      #             finalHaskell: prevHaskell:
-      #               {
-      #                 h3-hs = prevHaskell.callCabal2nix "h3-hs" ./. { h3 = final.h3_4; };
-      #                 # Use the following after upgrading nixpkgs
-      #                 # h3-hs = prevHaskell.h3-hs.override { h3 = final.h3_4; };
-      #               }
-      #         );
-      #     };
-      # };
+      # The following fixes the current hackage package tracked in nixpkgs
+      h3-hs-hackage-overlay = final: prev: {
+          haskell = prev.haskell // {
+              packageOverrides = final.lib.composeExtensions prev.haskell.packageOverrides (
+                  finalHaskell: prevHaskell:
+                    {
+                      # Remove the doJailBreak and nativeBuildInputs override when possible
+                      h3-hs = final.haskell.lib.doJailbreak (final.haskell.lib.markUnbroken (
+                        (prevHaskell.h3-hs.override { h3 = final.h3_4; }).overrideAttrs (prevAttrs: {
+                            nativeBuildInputs = prevAttrs.nativeBuildInputs ++ [ finalHaskell.c2hs ];
+                        })
+                      ));
+                    }
+              );
+          };
+      };
     in 
       flake-utils.lib.eachDefaultSystem (system:
         let 
@@ -67,102 +66,91 @@
             overlays = [ h3-hs-source-overlay ];
           };
           
-          # release-pkgs = import nixpkgs {
-          #   inherit system;
-          #   overlays = [ h3-hs-hackage-overlay ];
-          # };
-   
-          build-package-map = hs: [hs.cabal-install hs.test-framework-quickcheck2 hs.c2hs ]; # hs.c2hs
-          # build-package-map-with-h3 = hs: [hs.cabal-install hs.test-framework-quickcheck2 hs.c2hs hs.h3-hs];
-          haskell-build-packages = [
+          release-pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ h3-hs-hackage-overlay ];
+          };
+  
+          base-packages = [
               pkgs.which
               pkgs.h3_4
-              pkgs.pkg-config
+          ];
+
+          build-package-map = hs: [hs.cabal-install hs.test-framework-quickcheck2 hs.c2hs ];
+          haskell-build-packages-default = base-packages ++ [
               (pkgs.haskellPackages.ghcWithPackages build-package-map)
           ];
-          # haskell-build-packages-with-h3 = [
-          #     pkgs.which
-          #     pkgs.h3_4
-          #     pkgs.pkg-config
-          #     (pkgs.haskellPackages.ghcWithPackages build-package-map-with-h3)
-          # ];
 
-          # release-haskell-package-map = hs: [hs.h3-hs hs.cabal-install hs.test-framework-quickcheck2];
-          # release-haskell-packages = [
-          #     pkgs.which
-          #     pkgs.h3_4
-          #     pkgs.pkg-config
-          #     # (pkgs.haskellPackages.ghcWithPackages (hs: [hs.h3-hs hs.cabal-install hs.c2hs hs.test-framework-quickcheck2]))
-          #     # NOTE: Removed c2hs from the following
-          #     (pkgs.haskellPackages.ghcWithPackages release-haskell-package-map) # (hs: [hs.h3-hs hs.cabal-install hs.test-framework-quickcheck2])
-          # ];
+          haskell-build-packages-for-version = ghcversion: haskellpackages: (base-packages ++ [
+              (pkgs.haskell.packages.${ghcversion}.ghcWithPackages haskellpackages)
+          ]);
+          
+          test-package-map = hs: [hs.cabal-install hs.test-framework-quickcheck2 hs.c2hs hs.h3-hs ];
+          haskell-build-packages-test = base-packages ++ [
+              (pkgs.haskellPackages.ghcWithPackages test-package-map)
+          ];
       in rec {
-        # devShell = devShells.default; 
-        # pkgs.mkShell {
-        #   packages = dev-haskell-packages;
-        #   # inputsFrom = dev-haskell-packages;
-        #   nativeBuildInputs = [ pkgs.haskellPackages.c2hs ]; #  dev-haskell-packages;
-        #   # buildInputs = dev-haskell-packages;
-        #   # propagatedBuildInputs = dev-haskell-packages;
-        #   # nativeBuildInputs = dev-haskell-packages;
-        #   # packages = [ 
-        #   #     pkgs.haskellPackages.cabal-install
-        #   #     pkgs.haskellPackages.c2hs
-        #   # ];
-        #   shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev > \\[\\e[0m\\]'";
-        # };
         devShells = {
             default = pkgs.mkShell {
-              packages = haskell-build-packages;
-              # inputsFrom = dev-haskell-packages;
-              nativeBuildInputs = [ pkgs.haskellPackages.c2hs ]; #  dev-haskell-packages;
-              # buildInputs = dev-haskell-packages;
-              # propagatedBuildInputs = dev-haskell-packages;
-              # nativeBuildInputs = dev-haskell-packages;
-              # packages = [ 
-              #     pkgs.haskellPackages.cabal-install
-              #     pkgs.haskellPackages.c2hs
-              # ];
-              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev > \\[\\e[0m\\]'";
+              packages = haskell-build-packages-default;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
             };
-            ex-h3-hs = pkgs.mkShell {
-              packages = [ pkgs.h3_4 (pkgs.haskellPackages.ghcWithPackages (hs: [hs.cabal-install hs.test-framework-quickcheck2])) ];
-              nativeBuildInputs = [ pkgs.haskellPackages.c2hs ];
-              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev (ex h3-hs) > \\[\\e[0m\\]'";
+            ghc948shell = pkgs.mkShell {
+              # packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc948.ghcWithPackages build-package-map) ];
+              packages = haskell-build-packages-for-version "ghc948" build-package-map;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.4.8) > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
             };
-            legacy = pkgs.haskellPackages.shellFor {
-                packages = p: [p.h3-hs];
-                withHoogle = true;
-                buildInputs =((with pkgs; [ h3_4 ]) ++ (with pkgs.haskellPackages; [ cabal-install c2hs ]));
-                shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-shellfor > \\[\\e[0m\\]'";
-                # exactDeps = false;
+            ghc967shell = pkgs.mkShell {
+              # packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc967.ghcWithPackages build-package-map) ];
+              packages = haskell-build-packages-for-version "ghc967" build-package-map;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.6.7) > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
             };
-            ghc928shell = pkgs.mkShell {
-              packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc928.ghcWithPackages build-package-map) ];
-              # inputsFrom = [ (pkgs.haskell.packages.ghc928.ghcWithPackages (hs: [hs.c2hs])) ];
-              # buildInputs = [ (pkgs.haskell.packages.ghc928.ghcWithPackages (hs: [hs.c2hs])) ];
-              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev (ghc-9.2.8) > \\[\\e[0m\\]'";
+            ghc984shell = pkgs.mkShell {
+              # packages = [ pkgs.which pkgs.h3_4 (pkgs.haskell.packages.ghc984.ghcWithPackages build-package-map) ];
+              packages = haskell-build-packages-for-version "ghc984" build-package-map;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.8.4) > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
             };
-            ghc982shell = pkgs.mkShell {
-              # buildInputs = [ pkgs.h3_4 (pkgs.haskell.packages.ghc982.ghcWithPackages (hs: [hs.h3-hs hs.cabal-install hs.c2hs hs.test-framework-quickcheck2]))];
-              # inputsFrom = [ (pkgs.haskell.packages.ghc982.ghcWithPackages (hs: [hs.c2hs])) ];
-              # nativeBuildInputs = [ (pkgs.haskell.packages.ghc982.ghcWithPackages (hs: [hs.c2hs])) ];
-              # buildInputs = [ (pkgs.haskell.packages.ghc982.ghcWithPackages (hs: [hs.c2hs])) ];
-              packages = [ pkgs.which pkgs.h3_4 (pkgs.haskell.packages.ghc982.ghcWithPackages build-package-map) ];
-              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs-dev (ghc-9.8.2) > \\[\\e[0m\\]'";
+            ghc9103shell = pkgs.mkShell {
+              packages = haskell-build-packages-for-version "ghc9103" build-package-map;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.10.3) > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
             };
-            # package-test = pkgs.mkShell {
-            #   packages = haskell-build-packages-with-h3;
-            #   # nativeBuildInputs = [ pkgs.haskellPackages.c2hs ];
-            #   shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs (package test) > \\[\\e[0m\\]'";
-            # };
+            ghc9122shell = pkgs.mkShell {
+              packages = haskell-build-packages-for-version "ghc9122" build-package-map;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.12.2) > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
+            };
+            packageTest = pkgs.mkShell {
+              # This is for testing the package build.  Use `ghci` rather than `cabal repl` for manual testing.
+              packages = haskell-build-packages-test;
+              shellHook = "export PS1='\\[\\e[1;34m\\]h3-hs (package test) > \\[\\e[0m\\]'";
+            };
         };
         packages = {
-          h3-hs = pkgs.haskellPackages.h3-hs;
           default = pkgs.haskellPackages.h3-hs;
+          h3-hs = pkgs.haskellPackages.h3-hs;
+          hackage-h3-hs = release-pkgs.haskellPackages.h3-hs;
         };
       }
     ) // {
       overlays.default = h3-hs-source-overlay;
+      overlays.h3-hs-source = h3-hs-source-overlay;
+      overlays.h3-hs-hackage = h3-hs-hackage-overlay;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,6 @@
               '';
             };
             ghc948shell = pkgs.mkShell {
-              # packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc948.ghcWithPackages build-package-map) ];
               packages = haskell-build-packages-for-version "ghc948" build-package-map;
               shellHook = ''
                 export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.4.8) > \\[\\e[0m\\]"
@@ -107,7 +106,6 @@
               '';
             };
             ghc967shell = pkgs.mkShell {
-              # packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc967.ghcWithPackages build-package-map) ];
               packages = haskell-build-packages-for-version "ghc967" build-package-map;
               shellHook = ''
                 export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.6.7) > \\[\\e[0m\\]"
@@ -115,7 +113,6 @@
               '';
             };
             ghc984shell = pkgs.mkShell {
-              # packages = [ pkgs.which pkgs.h3_4 (pkgs.haskell.packages.ghc984.ghcWithPackages build-package-map) ];
               packages = haskell-build-packages-for-version "ghc984" build-package-map;
               shellHook = ''
                 export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.8.4) > \\[\\e[0m\\]"

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -20,7 +20,7 @@ name:               h3-hs
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:            0.2.0.1
+version:            0.2.0.2
 
 -- A short (one-line) description of the package.
 synopsis:           A Haskell binding for H3
@@ -105,14 +105,14 @@ library
 
     -- Other library packages from which modules are imported.
     build-depends:
-        base ^>= 4.18.1.0 || ^>=4.17.2.1 || ^>=4.16.4.0 || ^>= 4.15.1.0 || ^>= 4.14.3.0
+        base ^>= 4.19.1.0 || ^>= 4.18.1.0 || ^>=4.17.2.1 || ^>=4.16.4.0 || ^>= 4.15.1.0 || ^>= 4.14.3.0
 
     -- Directories containing source files.
     hs-source-dirs:   src
 
     extra-libraries: h3
 
-    -- build-tool-depends: c2hs:c2hs
+    -- build-tool-depends: c2hs:c2hs ^>= 0.28.8
 
     -- Base language which the package is written in.
     default-language: Haskell2010

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -69,7 +69,7 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC==9.6.3 GHC==9.4.8 GHC==9.2.8 GHC==9.0.2 GHC==8.10.7
+tested-with: GHC==9.12.2 GHC==9.10.3 GHC==9.8.4 GHC==9.6.7 GHC==9.6.3 GHC==9.4.8 GHC==9.2.8 GHC==9.0.2 GHC==8.10.7
 
 source-repository head
   type: git
@@ -105,14 +105,14 @@ library
 
     -- Other library packages from which modules are imported.
     build-depends:
-        base ^>= 4.19.1.0 || ^>= 4.18.1.0 || ^>=4.17.2.1 || ^>=4.16.4.0 || ^>= 4.15.1.0 || ^>= 4.14.3.0
+        base ^>= 4.21.0.0 || ^>= 4.20.2.0 || ^>= 4.19.1.0 || ^>= 4.18.1.0 || ^>=4.17.2.1 || ^>=4.16.4.0 || ^>= 4.15.1.0 || ^>= 4.14.3.0
 
     -- Directories containing source files.
     hs-source-dirs:   src
 
     extra-libraries: h3
 
-    -- build-tool-depends: c2hs:c2hs ^>= 0.28.8
+    build-tool-depends: c2hs:c2hs ^>= 0.28.8
 
     -- Base language which the package is written in.
     default-language: Haskell2010
@@ -153,7 +153,7 @@ test-suite h3-hs-test
     build-depends:
         base,
         h3-hs,
-        QuickCheck ^>= 2.14.3,
+        QuickCheck >= 2.14.3 && < 2.16,
         test-framework ^>= 0.8.2,
         test-framework-quickcheck2 ^>= 0.3.0.5
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,8 +1,0 @@
-let
-  pkgs = import <nixpkgs> { }; 
-in
-pkgs.haskellPackages.developPackage {
-  root = ./.;
-  modifier = drv: pkgs.haskell.lib.addBuildTools drv ((with pkgs; [ h3_4 ]) ++ (with pkgs.haskellPackages ; [ cabal-install c2hs ]));
-  returnShellEnv = true;
-}


### PR DESCRIPTION
We introduce a nix flake to replace the nix shell.  This will include an overlay which correctly sets the `h3` library to use when building with nix.