### PR TITLE
New GHC shells in flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772598333,
-        "narHash": "sha256-YaHht/C35INEX3DeJQNWjNaTcPjYmBwwjFJ2jdtr+5U=",
+        "lastModified": 1772822230,
+        "narHash": "sha256-yf3iYLGbGVlIthlQIk5/4/EQDZNNEmuqKZkQssMljuw=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "fabb8c9deee281e50b1065002c9828f2cf7b2239",
+        "rev": "71caefce12ba78d84fe618cf61644dce01cf3a96",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -98,19 +98,41 @@
                 export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
               '';
             };
-            ghc928shell = pkgs.mkShell {
-              # packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc928.ghcWithPackages build-package-map) ];
-              packages = haskell-build-packages-for-version "ghc928" build-package-map;
+            ghc948shell = pkgs.mkShell {
+              # packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc948.ghcWithPackages build-package-map) ];
+              packages = haskell-build-packages-for-version "ghc948" build-package-map;
               shellHook = ''
-                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.2.8) > \\[\\e[0m\\]"
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.4.8) > \\[\\e[0m\\]"
                 export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
               '';
             };
-            ghc982shell = pkgs.mkShell {
-              # packages = [ pkgs.which pkgs.h3_4 (pkgs.haskell.packages.ghc982.ghcWithPackages build-package-map) ];
-              packages = haskell-build-packages-for-version "ghc982" build-package-map;
+            ghc967shell = pkgs.mkShell {
+              # packages = [ pkgs.h3_4 (pkgs.haskell.packages.ghc967.ghcWithPackages build-package-map) ];
+              packages = haskell-build-packages-for-version "ghc967" build-package-map;
               shellHook = ''
-                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.8.2) > \\[\\e[0m\\]"
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.6.7) > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
+            };
+            ghc984shell = pkgs.mkShell {
+              # packages = [ pkgs.which pkgs.h3_4 (pkgs.haskell.packages.ghc984.ghcWithPackages build-package-map) ];
+              packages = haskell-build-packages-for-version "ghc984" build-package-map;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.8.4) > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
+            };
+            ghc9103shell = pkgs.mkShell {
+              packages = haskell-build-packages-for-version "ghc9103" build-package-map;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.10.3) > \\[\\e[0m\\]"
+                export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
+              '';
+            };
+            ghc9122shell = pkgs.mkShell {
+              packages = haskell-build-packages-for-version "ghc9122" build-package-map;
+              shellHook = ''
+                export PS1="\\[\\e[1;34m\\]h3-hs-dev (ghc-9.12.2) > \\[\\e[0m\\]"
                 export LD_LIBRARY_PATH=${pkgs.h3_4}/lib:$LD_LIBRARY_PATH
               '';
             };

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -69,7 +69,7 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC==9.10.3 GHC==9.6.7 GHC==9.6.3 GHC==9.4.8 GHC==9.2.8 GHC==9.0.2 GHC==8.10.7
+tested-with: GHC==9.12.2 GHC==9.10.3 GHC==9.6.7 GHC==9.6.3 GHC==9.4.8 GHC==9.2.8 GHC==9.0.2 GHC==8.10.7
 
 source-repository head
   type: git

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -69,7 +69,7 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC==9.12.2 GHC==9.10.3 GHC==9.6.7 GHC==9.6.3 GHC==9.4.8 GHC==9.2.8 GHC==9.0.2 GHC==8.10.7
+tested-with: GHC==9.12.2 GHC==9.10.3 GHC==9.8.4 GHC==9.6.7 GHC==9.6.3 GHC==9.4.8 GHC==9.2.8 GHC==9.0.2 GHC==8.10.7
 
 source-repository head
   type: git

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -69,7 +69,7 @@ extra-doc-files:    CHANGELOG.md
 -- Extra source files to be distributed with the package, such as examples, or a tutorial module.
 -- extra-source-files:
 
-tested-with: GHC==9.6.3 GHC==9.4.8 GHC==9.2.8 GHC==9.0.2 GHC==8.10.7
+tested-with: GHC==9.10.3 GHC==9.6.7 GHC==9.6.3 GHC==9.4.8 GHC==9.2.8 GHC==9.0.2 GHC==8.10.7
 
 source-repository head
   type: git

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -105,7 +105,7 @@ library
 
     -- Other library packages from which modules are imported.
     build-depends:
-        base ^>= 4.20.2.0 || ^>= 4.19.1.0 || ^>= 4.18.1.0 || ^>=4.17.2.1 || ^>=4.16.4.0 || ^>= 4.15.1.0 || ^>= 4.14.3.0
+        base ^>= 4.21.0.0 || ^>= 4.20.2.0 || ^>= 4.19.1.0 || ^>= 4.18.1.0 || ^>=4.17.2.1 || ^>=4.16.4.0 || ^>= 4.15.1.0 || ^>= 4.14.3.0
 
     -- Directories containing source files.
     hs-source-dirs:   src


### PR DESCRIPTION
Removing the GHC 9.2 shell, and adding development shells for 9.10.3 and 9.12.2.  Updating the "tested-with" field in the cabal file.