### PR TITLE
Return boolean for cell classification methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for h3-hs
 
+## 0.2.0.2
+
+Updating dependencies in the cabal file.
+
 ## 0.2.0.1
 
 Updating the documentation to indicate that `gridDiskDistancesSafe` can hang. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for h3-hs
 
+## 0.3.0.0
+
+`isValidCell`, `isResClassIII`, and `isPentagon` now return a boolean.
+
 ## 0.2.0.2
 
 Updating dependencies in the cabal file.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2024, Justin Smith, jvstinian.com
+Copyright (c) 2024-2026, Justin Smith, jvstinian.com
 
 All rights reserved.
 

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -20,7 +20,7 @@ name:               h3-hs
 -- PVP summary:     +-+------- breaking API changes
 --                  | | +----- non-breaking API additions
 --                  | | | +--- code changes with no API change
-version:            0.2.0.2
+version:            0.3.0.0
 
 -- A short (one-line) description of the package.
 synopsis:           A Haskell binding for H3

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -73,7 +73,7 @@ tested-with: GHC==9.12.2 GHC==9.10.3 GHC==9.8.4 GHC==9.6.7 GHC==9.6.3 GHC==9.4.8
 
 source-repository head
   type: git
-  location: git://github.com/jvstinian/h3-hs.git
+  location: https://github.com/jvstinian/h3-hs
 
 common warnings
     ghc-options: -Wall -g

--- a/h3-hs.cabal
+++ b/h3-hs.cabal
@@ -59,7 +59,7 @@ author:             Justin Smith
 maintainer:         jvstinian@gmail.com
 
 -- A copyright notice.
-copyright:          (c) 2024 Justin Smith
+copyright:          (c) 2024-2026 Justin Smith
 category:           Geography
 build-type:         Simple
 

--- a/src/H3/Internal/FFI.hs
+++ b/src/H3/Internal/FFI.hs
@@ -61,14 +61,26 @@ foreign import capi "h3/h3api.h getResolution" getResolution :: H3Index -> Int
 -- | Returns the base cell number of the index.
 foreign import capi "h3/h3api.h getBaseCellNumber" getBaseCellNumber :: H3Index -> Int
 
--- | isValidCell returns non-zero if this is a valid H3 cell index
-foreign import capi "h3/h3api.h isValidCell" isValidCell :: H3Index -> Int
+-- | cIsValidCell returns non-zero if this is a valid H3 cell index
+foreign import capi "h3/h3api.h isValidCell" cIsValidCell :: H3Index -> Int
+
+-- | isValidCell returns True if this is a valid H3 cell index
+isValidCell :: H3Index -> Bool
+isValidCell = (/=0) . cIsValidCell
 
 -- | Returns non-zero if this index has a resolution with Class III orientation.
-foreign import capi "h3/h3api.h isResClassIII" isResClassIII :: H3Index -> Int
+foreign import capi "h3/h3api.h isResClassIII" cIsResClassIII :: H3Index -> Int
+
+-- | Returns True if this index has a resolution with Class III orientation.
+isResClassIII :: H3Index -> Bool
+isResClassIII = (/=0) . cIsResClassIII
 
 -- | Returns non-zero if this index represents a pentagonal cell.
-foreign import capi "h3/h3api.h isPentagon" isPentagon :: H3Index -> Int
+foreign import capi "h3/h3api.h isPentagon" cIsPentagon :: H3Index -> Int
+
+-- | Returns True if this index represents a pentagonal cell.
+isPentagon :: H3Index -> Bool
+isPentagon = (/=0) . cIsPentagon
 
 foreign import capi "h3/h3api.h maxFaceCount" c_maxFaceCount :: H3Index -> Ptr CInt -> IO H3Error
 

--- a/test/InspectionTest.hs
+++ b/test/InspectionTest.hs
@@ -64,7 +64,7 @@ testIsInvalidCell :: Test
 testIsInvalidCell = testProperty "Testing invalid cell value" $
     actualResultE == expectedResultE
     where
-        actualResultE = (/=0) . isValidCell <$> (stringToH3 "85283473ffff")
+        actualResultE = isValidCell <$> (stringToH3 "85283473ffff")
         expectedResultE = Right False
 
 -- The following is from https://github.com/uber/h3/blob/master/tests/cli/isValidCell.txt
@@ -72,14 +72,14 @@ testIsValidCell :: Test
 testIsValidCell = testProperty "Testing cell value is valid" $
     actualResultE == expectedResultE
     where
-        actualResultE = (/=0) . isValidCell <$> (stringToH3 "85283473fffffff")
+        actualResultE = isValidCell <$> (stringToH3 "85283473fffffff")
         expectedResultE = Right True
 
 testIsResClassIII :: Test
 testIsResClassIII = testProperty "Testing isResClassIII" $
     actualResultE == expectedResultE
     where
-        actualResultE = (/=0) . isResClassIII <$> (stringToH3 "85283473fffffff")
+        actualResultE = isResClassIII <$> (stringToH3 "85283473fffffff")
         expectedResultE = Right True
 
 -- This is taken from https://github.com/uber/h3/blob/master/tests/cli/isPentagon.txt
@@ -87,7 +87,7 @@ testIsPentagon :: Test
 testIsPentagon = testProperty "Testing isPentagon" $
     actualResultE == expectedResultE
     where
-        actualResultE = (/=0) . isPentagon <$> (stringToH3 "85283473fffffff")
+        actualResultE = isPentagon <$> (stringToH3 "85283473fffffff")
         expectedResultE = Right False
 
 -- This is taken from https://github.com/uber/h3/blob/master/tests/cli/getIcosahedronFaces.txt
@@ -129,7 +129,7 @@ testIntToStringToInt = testProperty "test conversion from int to string and back
 
 testIsValidWithMockData :: Test
 testIsValidWithMockData = testProperty "test isValidCell" $ \(GenLatLng latLng) (Resolution res) ->
-    let actualResultE = (/=0) . isValidCell <$> latLngToCell latLng res
+    let actualResultE = isValidCell <$> latLngToCell latLng res
         expectedResultE = Right True
     in 
     actualResultE == expectedResultE

--- a/test/TestTypes.hs
+++ b/test/TestTypes.hs
@@ -17,5 +17,5 @@ newtype GenLatLng = GenLatLng { fromGenLatLng :: LatLng }
   deriving (Eq, Show)
 
 instance Arbitrary GenLatLng where
-    arbitrary = GenLatLng <$> liftM2 LatLng (choose (-pi, pi)) (choose (-pi, pi))
+    arbitrary = GenLatLng <$> liftM2 LatLng (choose (-pi/2, pi/2)) (choose (-pi, pi))
 

--- a/test/VertexesTest.hs
+++ b/test/VertexesTest.hs
@@ -38,8 +38,7 @@ tests =
 testCellToVertex :: Test
 testCellToVertex = testProperty "Test cellToVertex produces valid vertex indices" $ \(GenLatLng latLng) (Resolution res) (GenVertexNum vertexNum) ->
     let h3indexE = latLngToCell latLng res
-        isPentagonAsBool = (/=0) . isPentagon
-        isPent = either (const False) id (isPentagonAsBool <$> h3indexE)
+        isPent = either (const False) id (isPentagon <$> h3indexE)
         vertexIndexE = h3indexE >>= flip cellToVertex vertexNum
         resultE = isValidVertex <$> vertexIndexE
     in (not isPent || vertexNum <= 4) ==> (resultE == Right True)


### PR DESCRIPTION
We update `isValidCell`, `isResClassIII`, and `isPentagon` to return a boolean.

The generation of values of latitude in the tests is also updated.
